### PR TITLE
294 Create autogen subdomain from terraform

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,10 @@ Nullstone Block creating an AWS Subdomain from a Nullstone-generated subdomain (
 
 ## Inputs
 
-- `subdomain: string`
-  - This represents the token to prepend the input domain block (i.e. the fqdn is represented by `{var.subdomain}.<domain>.`)
-  - Example: `subdomain = random-slug` will create `random-slug.nullstone.app`
-
 ## Outputs
 
-- `name: string` - The created subdomain.
+- `name: string` - The name that precedes the domain name for the created subdomain.
+- `fqdn: string` - The FQDN (fully-qualified domain name) for the created subdomain.
 - `zone_id: string` - The zone ID of the AWS Route53 Zone for the created subdomain.
 - `nameservers: list(string)` - The list of nameservers of the AWS Route53 Zone for the created subdomain.
 - `domain_name: string` - The name of the root domain.

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,11 @@
 output "name" {
-  value       = aws_route53_zone.this.name
-  description = "string ||| The created subdomain."
+  value       = ns_autogen_subdomain.subdomain.name
+  description = "string ||| The name that precedes the domain name for the created subdomain."
+}
+
+output "fqdn" {
+  value       = ns_autogen_subdomain.subdomain.fqdn
+  description = "string ||| The FQDN (fully-qualified domain name) for the created subdomain."
 }
 
 output "zone_id" {
@@ -14,6 +19,6 @@ output "nameservers" {
 }
 
 output "domain_name" {
-  value       = data.ns_autogen_subdomain.subdomain.domain_name
+  value       = ns_autogen_subdomain.subdomain.domain_name
   description = "string ||| The name of the root domain."
 }

--- a/subdomain.tf
+++ b/subdomain.tf
@@ -1,9 +1,7 @@
-data "ns_autogen_subdomain" "subdomain" {
-  name = var.subdomain
-}
+resource "ns_autogen_subdomain" "subdomain" {}
 
 resource "aws_route53_zone" "this" {
-  name = data.ns_autogen_subdomain.subdomain.fqdn
+  name = ns_autogen_subdomain.subdomain.fqdn
   tags = data.ns_workspace.this.tags
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,4 +1,0 @@
-variable "subdomain" {
-  type        = string
-  description = "This represents the token to prepend the input domain block (i.e. the fqdn is represented by {var.subdomain}.<domain>.)"
-}


### PR DESCRIPTION
This PR changes the module to create the autogen subdomain in nullstone from Terraform.
Previously, this was created by a user in the UI and retrieved from Terraform.
This makes it simple to use autogen subdomains across multiple environments for a single block.

### TODO
- [x] Review and merge https://github.com/nullstone-io/terraform-provider-ns/pull/7
- [x] Publish new version of terraform-provider-ns
- [ ] Merge and publish this module