### PR TITLE
C307 autogen subdomains

### DIFF
--- a/subdomain.tf
+++ b/subdomain.tf
@@ -1,11 +1,20 @@
-resource "ns_autogen_subdomain" "subdomain" {}
+data "ns_subdomain" "subdomain" {
+  stack = data.ns_workspace.this.stack
+  block = data.ns_workspace.this.block
+}
+
+resource "ns_autogen_subdomain" "autogen_subdomain" {
+  subdomain_id = data.ns_subdomain.id
+  env = data.ns_workspace.this.env
+}
 
 resource "aws_route53_zone" "this" {
-  name = ns_autogen_subdomain.subdomain.fqdn
+  name = ns_autogen_subdomain.autogen_subdomain.fqdn
   tags = data.ns_workspace.this.tags
 }
 
 resource "ns_autogen_subdomain_delegation" "to_aws" {
-  subdomain   = var.subdomain
+  subdomain_id = data.ns_subdomain.id
+  env = data.ns_workspace.this.env
   nameservers = aws_route53_zone.this.name_servers
 }

--- a/subdomain.tf
+++ b/subdomain.tf
@@ -5,7 +5,7 @@ data "ns_subdomain" "subdomain" {
 
 resource "ns_autogen_subdomain" "autogen_subdomain" {
   subdomain_id = data.ns_subdomain.id
-  env = data.ns_workspace.this.env
+  env          = data.ns_workspace.this.env
 }
 
 resource "aws_route53_zone" "this" {
@@ -15,6 +15,6 @@ resource "aws_route53_zone" "this" {
 
 resource "ns_autogen_subdomain_delegation" "to_aws" {
   subdomain_id = data.ns_subdomain.id
-  env = data.ns_workspace.this.env
-  nameservers = aws_route53_zone.this.name_servers
+  env          = data.ns_workspace.this.env
+  nameservers  = aws_route53_zone.this.name_servers
 }


### PR DESCRIPTION
This PR changes how this module is designed to work. In the new design, a subdomain is configured in a stack as a block. Then, if the module for the block is this module, it will create a new autogen_subdomain and delegate it for each environment.

In order to identify the autogen_subdomain to create and delegate we first pull in the subdomain block and get its id. We already have the env from the ns_workspace. The last piece is to make sure the ns_autogen_subdomain and ns_autogen_subdomain_delegation resources are passed these values so they can create and update accordingly.