### PR TITLE
Guarantee cert isn't tried until records exist

### DIFF
--- a/cert.tf
+++ b/cert.tf
@@ -8,4 +8,6 @@ module "cert" {
 
   tags    = data.ns_workspace.this.tags
   enabled = var.create_cert
+
+  depends_on = [ns_autogen_subdomain_delegation.to_aws]
 }


### PR DESCRIPTION
This PR alters the order of execution to prevent the certificate from trying to issue until after the domain records have been created.
This will have 2 effects:
1. Give the user a single message when something goes wrong
2. If something else errors, we won't wait 5m for the cert validation to timeout